### PR TITLE
Mention the `--allow-no-tests` option in the CLI documentation

### DIFF
--- a/user_guide/command_line_tool.rst
+++ b/user_guide/command_line_tool.rst
@@ -97,6 +97,8 @@ This is a summary of the usage of Behat in the command line:
       --dry-run
           Invokes formatters without executing the tests and
           hooks.
+      --allow-no-tests
+          Will not fail if no specifications are found.
       -p, --profile=PROFILE
           Specify config profile to use.
       -c, --config=CONFIG


### PR DESCRIPTION
Just adds the new flag from Behat/Behat#1420 to the overview of CLI options.

Can merge after Behat/Behat#1613 is released.